### PR TITLE
updated the files for the time zone

### DIFF
--- a/frappe/core/doctype/file/file.json
+++ b/frappe/core/doctype/file/file.json
@@ -23,6 +23,7 @@
   "is_folder",
   "section_break_8",
   "attached_to_doctype",
+  "route_link",
   "column_break_10",
   "attached_to_name",
   "attached_to_field",
@@ -184,13 +185,18 @@
    "in_standard_filter": 1,
    "label": "File Type",
    "read_only": 1
+  },
+  {
+   "fieldname": "route_link",
+   "fieldtype": "Data",
+   "label": "Route Link"
   }
  ],
  "force_re_route_to_default_view": 1,
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2025-01-15 11:46:42.917146",
+ "modified": "2026-01-04 13:49:16.621117",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "File",
@@ -217,6 +223,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -57,6 +57,7 @@ class File(Document):
 		is_home_folder: DF.Check
 		is_private: DF.Check
 		old_parent: DF.Data | None
+		route_link: DF.Data | None
 		thumbnail_url: DF.SmallText | None
 		uploaded_to_dropbox: DF.Check
 		uploaded_to_google_drive: DF.Check

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -757,6 +757,8 @@ class SendMailContext:
 		message = message.replace(
 			self.message_placeholder("recipient"), self.get_recipient_str(recipient_email)
 		)
+		# Convert timezone markers for this recipient
+		message = self.convert_timezone_markers(message, recipient_email)
 		message = self.include_attachments(message)
 		return message
 
@@ -809,6 +811,115 @@ class SendMailContext:
 
 	def get_recipient_str(self, recipient_email):
 		return recipient_email if self.queue_doc.expose_recipients != "header" else ""
+
+	def convert_timezone_markers(self, message: str, recipient_email: str) -> str:
+		"""
+		Convert all data-utc timezone markers to recipient's timezone.
+
+		Handles MIME-encoded messages by decoding, converting, then re-encoding.
+
+		Markers format: <span data-utc="2025-01-15T10:30:00Z">15 Jan 2025 04:00 PM (UTC+05:30)</span>
+		Output format: 15 Jan 2025 11:30 AM (UTC-05:00)
+		"""
+		import re
+		import pytz
+		from datetime import datetime
+		from email.parser import Parser
+		from email.policy import SMTP
+
+		# Get recipient timezone
+		recipient_tz = self.get_recipient_timezone(recipient_email)
+
+		try:
+			target_timezone = pytz.timezone(recipient_tz)
+		except Exception:
+			return message  # Invalid timezone, return unchanged
+
+		# Parse the MIME message
+		try:
+			msg = Parser(policy=SMTP).parsestr(message)
+		except Exception:
+			return message  # Can't parse, return unchanged
+
+		def convert_html_content(html_content: str) -> str:
+			"""Apply timezone conversion to decoded HTML content."""
+			# Pattern: <span data-utc="2025-01-15T10:30:00Z">any text</span>
+			datetime_pattern = r'<span data-utc="([^"]+)">([^<]*)</span>'
+
+			def replace_datetime(match):
+				utc_str = match.group(1)
+				try:
+					# Parse UTC datetime
+					utc_dt = datetime.strptime(utc_str, '%Y-%m-%dT%H:%M:%SZ')
+					utc_dt = pytz.UTC.localize(utc_dt)
+
+					# Convert to target timezone
+					local_dt = utc_dt.astimezone(target_timezone)
+
+					# Format: "15 Jan 2025 04:00 PM (UTC+05:30)"
+					offset = local_dt.strftime('%z')
+					offset_formatted = f"UTC{offset[:3]}:{offset[3:]}"
+					formatted_time = local_dt.strftime('%d %b %Y %I:%M %p')
+
+					return f"{formatted_time} ({offset_formatted})"
+				except Exception:
+					return match.group(2)  # Return original text on error
+
+			# Convert datetime markers
+			result = re.sub(datetime_pattern, replace_datetime, html_content)
+
+			# Strip date-only markers (no timezone conversion needed)
+			date_pattern = r'<span data-date="[^"]+">([^<]*)</span>'
+			result = re.sub(date_pattern, r'\1', result)
+
+			return result
+
+		def process_part(part):
+			"""Process a single MIME part."""
+			content_type = part.get_content_type()
+
+			if content_type in ('text/html', 'text/plain'):
+				try:
+					# Get the payload (decoded)
+					charset = part.get_content_charset() or 'utf-8'
+					payload = part.get_payload(decode=True)
+
+					if payload:
+						decoded_content = payload.decode(charset, errors='replace')
+
+						# Apply timezone conversion
+						converted_content = convert_html_content(decoded_content)
+
+						# Set the new payload
+						part.set_payload(converted_content, charset=charset)
+				except Exception:
+					pass  # Keep original on error
+
+		# Process the message
+		if msg.is_multipart():
+			for part in msg.walk():
+				process_part(part)
+		else:
+			process_part(msg)
+
+		# Return the modified message as string
+		return msg.as_string()
+
+	def get_recipient_timezone(self, recipient_email: str) -> str:
+		"""
+		Get timezone for a recipient by email.
+		Falls back to system timezone if user not found or no timezone set.
+		"""
+		from frappe.utils import get_system_timezone
+
+		try:
+			user_tz = frappe.db.get_value("User", recipient_email, "time_zone")
+			if user_tz:
+				return user_tz
+		except Exception:
+			pass
+
+		return get_system_timezone()
 
 	def include_attachments(self, message):
 		message_obj = self.get_message_object(message)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -349,6 +349,92 @@ def convert_utc_to_system_timezone(utc_timestamp):
 	return convert_utc_to_timezone(utc_timestamp, time_zone)
 
 
+def format_datetime_with_tz_marker(dt_value, fallback=""):
+	"""
+	Format datetime with UTC marker for per-recipient timezone conversion in emails.
+
+	Output: <span data-utc="2025-01-15T10:30:00Z">15 Jan 2025 04:00 PM (UTC+05:30)</span>
+
+	The data-utc attribute stores UTC time, which gets converted to each
+	recipient's timezone in email_queue.py's build_message() method.
+
+	Args:
+		dt_value: Datetime object or string (in system timezone)
+		fallback: Value to return if dt_value is None
+
+	Returns:
+		HTML span with UTC data attribute and formatted display text
+	"""
+	if not dt_value:
+		return fallback
+
+	try:
+		# Parse to datetime if string
+		if isinstance(dt_value, str):
+			for fmt in ['%Y-%m-%d %H:%M:%S.%f', '%Y-%m-%d %H:%M:%S', '%Y-%m-%d']:
+				try:
+					dt = datetime.datetime.strptime(dt_value, fmt)
+					break
+				except ValueError:
+					continue
+			else:
+				return fallback
+		elif isinstance(dt_value, datetime.datetime):
+			dt = dt_value
+		else:
+			return fallback
+
+		# Get system timezone
+		system_tz_str = get_system_timezone()
+		system_tz = pytz.timezone(system_tz_str)
+
+		# Localize to system timezone (Frappe stores datetimes in system tz)
+		if dt.tzinfo is None:
+			local_dt = system_tz.localize(dt)
+		else:
+			local_dt = dt
+
+		# Convert to UTC for storage in marker
+		utc_dt = local_dt.astimezone(pytz.UTC)
+		utc_iso = utc_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+		# Format display time with timezone offset
+		offset = local_dt.strftime('%z')  # e.g., +0530
+		offset_formatted = f"UTC{offset[:3]}:{offset[3:]}"  # UTC+05:30
+		formatted_time = local_dt.strftime('%d %b %Y %I:%M %p')
+		display_text = f"{formatted_time} ({offset_formatted})"
+
+		# Wrap in span with UTC data attribute
+		return f'<span data-utc="{utc_iso}">{display_text}</span>'
+
+	except Exception:
+		return fallback
+
+
+def format_date_with_tz_marker(date_value, fallback=""):
+	"""
+	Format date with marker for consistency. Dates don't need timezone conversion.
+
+	Args:
+		date_value: Date object or string
+		fallback: Value to return if date_value is None
+
+	Returns:
+		HTML span with data-date attribute (for stripping during send)
+	"""
+	if not date_value:
+		return fallback
+
+	try:
+		if hasattr(date_value, 'strftime'):
+			formatted = date_value.strftime('%d %b %Y')
+			iso_date = date_value.strftime('%Y-%m-%d')
+			return f'<span data-date="{iso_date}">{formatted}</span>'
+		return str(date_value)
+	except Exception:
+		return fallback
+
+
 def now() -> str:
 	"""return current datetime as yyyy-mm-dd hh:mm:ss"""
 	if frappe.flags.current_date:


### PR DESCRIPTION
updated the email queue for the time zone implementation. it will take the recipient time zone to show the date and date time for the template data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email timestamps now convert to each recipient’s local timezone and show UTC offset (e.g., "23 Dec 2024 02:30 PM (UTC+05:30)").
  * Date/time markers in content are standardized so emails display consistent, localized datetime and date spans.
  * Added a "Route Link" field to File records for storing route-related links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->