### PR TITLE
added a support of auth token in socket connection, along with header

### DIFF
--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -59,6 +59,15 @@ function authenticate_with_frappe(socket, next) {
 	let cookies = cookie.parse(socket.request.headers.cookie || "");
 	let authorization_header = socket.request.headers.authorization;
 
+	// Support token from Socket.IO auth object or query parameter (for WebSocket transport)
+	// WebSocket cannot send custom headers, so external clients pass token via auth/query
+	if (!authorization_header && socket.handshake) {
+		const auth_token = socket.handshake.auth?.token || socket.handshake.query?.token;
+		if (auth_token) {
+			authorization_header = auth_token;
+		}
+	}
+
 	// Allow connection if either cookie or authorization header is present
 	// (removed strict cookie requirement for external clients using auth headers)
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket clients can now authenticate using Socket.IO handshake tokens (auth object or query parameters) as an alternative to Authorization headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->